### PR TITLE
Add kubectl deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Manages Helm charts running in Kubernetes clusters.
 ### Other features
 * Use it as a [Drone](https://drone.io/) plugin for CI/CD.
 * Read secrets from environment variables.
+* Deploy helm charts with helm/tiller or independently with kubectl
 
 ## How to use
 ### Command line
@@ -106,7 +107,7 @@ helm:
       url: https://example.com/my-private-repo/
 releases:
   - name: cluster-autoscaler  # Specify the release name
-    deployment: kubectl # REQUIRED: Specify how the chart should be installed helm/kubectl
+    deploymentMethod: kubectl # REQUIRED: Specify how the chart should be installed helm/kubectl
     namespace: kube-system  # Specify the namespace where to install
     version: 0.7.0  # Specify the version of the chart to install
     chartPath: stable/cluster-autoscaler
@@ -116,6 +117,13 @@ releases:
     version: ~1.x  # Supports the same syntax as Helm's --version flag
     chartPath: private-repo/my-chart
 ```
+
+#### Deployment Methods
+
+Deployment methods give cluster admins control of how their helm charts are deployed. Because not all
+clusters are able to run tiller admins may not be able to use helm to deploy their helm charts. Using
+a `kubectl` deployment method uses helm to fetch a chart, template the kubernetes manifests, and apply
+them via `kubectl create -f -`
 
 values/my-chart/default.yaml:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ helm:
       url: https://example.com/my-private-repo/
 releases:
   - name: cluster-autoscaler  # Specify the release name
+    deployment: kubectl # REQUIRED: Specify how the chart should be installed helm/kubectl
     namespace: kube-system  # Specify the namespace where to install
     version: 0.7.0  # Specify the version of the chart to install
     chartPath: stable/cluster-autoscaler
   - name: my-chart
+    deployment: helm
     namespace: kube-system
     version: ~1.x  # Supports the same syntax as Helm's --version flag
     chartPath: private-repo/my-chart

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,3 +1,4 @@
 package constants
 
 const HelmBin = "helm"
+const KubectlBin = "kubectl"

--- a/types/types.go
+++ b/types/types.go
@@ -19,13 +19,13 @@ type HelmRepo struct {
 }
 
 type Release struct {
-	Name       string     `yaml:"name"`
-	Deployment string     `yaml:"deployment"`
-	Version    string     `yaml:"version"`
-	ChartPath  string     `yaml:"chartPath"`
-	Overrides  []Override `yaml:"overrides,omitempty"`
-	Namespace  string     `yaml:"namespace,omitempty"`
-	ValueFiles []string   `yaml:"valueFiles,omitempty"`
+	Name             string     `yaml:"name"`
+	DeploymentMethod string     `yaml:"deploymentMethod"`
+	Version          string     `yaml:"version"`
+	ChartPath        string     `yaml:"chartPath"`
+	Overrides        []Override `yaml:"overrides,omitempty"`
+	Namespace        string     `yaml:"namespace,omitempty"`
+	ValueFiles       []string   `yaml:"valueFiles,omitempty"`
 }
 
 type Override struct {

--- a/types/types.go
+++ b/types/types.go
@@ -20,6 +20,7 @@ type HelmRepo struct {
 
 type Release struct {
 	Name       string     `yaml:"name"`
+	Deployment string     `yaml:"deployment"`
 	Version    string     `yaml:"version"`
 	ChartPath  string     `yaml:"chartPath"`
 	Overrides  []Override `yaml:"overrides,omitempty"`


### PR DESCRIPTION
Some clusters my not be able to run tiller for various reasons
this feature allows cluster admins to install helm charts with
kubectl instead of helm.

*** THIS IS NOT BACKWARDS COMPATIBLE ***
This change forces cluster configuration files to specify their deployment type old configuration files without the `deployment` field in the release section will not work