### PR TITLE
add charts download option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ impeller
 # Folders
 _obj
 _test
-
+downloads
+wget-log
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Manages Helm charts running in Kubernetes clusters.
 `impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context --diff-run`
 1. Generate Audit report file:
 `impeller --cluster-config-path=./clusters  --audit=true`
-or 
+or
 `impeller --cluster-config-path=./clusters  --audit=true --audit-file=./myreport.csv`
 
 ### Drone pipeline
@@ -147,4 +147,19 @@ resources:
   memory:
     requests: 1Gi
     limits: 1Gi
+```
+
+### Deploying Release from tar file
+
+1. Add `chartsSource` field to the `release` to make impeller download charts tar archive
+1. Set `chartPath` to point to extracted chart location.
+
+```
+releases:
+  - name: istio-base
+    namespace: kube-system
+    version: ~x.x.x
+    chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
+    chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"
+
 ```

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,4 +1,6 @@
 package constants
 
 const HelmBin = "helm"
+const WgetBin = "wget"
+const TarBin = "tar"
 const KubectlBin = "kubectl"

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func run(ctx *cli.Context) error {
 			return fmt.Errorf("Kube context not set.")
 		}
 	}
-	if ctx.String("audit") == "" {
+	if ctx.String("audit") != "true" {
 		clusterConfig, err = utils.ReadClusterConfig(ctx.String("cluster-config-path"))
 		if err != nil {
 			return fmt.Errorf("Error reading cluster config: %v", err)

--- a/plugin.go
+++ b/plugin.go
@@ -274,7 +274,7 @@ func (p *Plugin) downloadCharts(release *types.Release) (string, error) {
 
 	if _, err := os.Stat(tarFilePath); err != nil || os.IsExist(err) {
 		log.Println("Downloading:", tarFilePath)
-		cmd := exec.Command(constants.WgetBin, "-q", "-n", "-P", "./downloads", release.ChartsSource)
+		cmd := exec.Command(constants.WgetBin, "-P", "./downloads", release.ChartsSource)
 		if err := utils.Run(cmd, true); err != nil {
 			return "", fmt.Errorf("Error extracting Charts archive: %v", err)
 		}

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -1,0 +1,13 @@
+name: cluster2-lab
+helm:
+  log: 0
+  debug: true
+  repos:
+    - name: stable
+      url: https://kubernetes-charts.storage.googleapis.com/
+releases:
+  - name: istio-base
+    namespace: kube-system
+    version: ~x.x.x
+    chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
+    chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"

--- a/types/types.go
+++ b/types/types.go
@@ -23,6 +23,7 @@ type Release struct {
 	DeploymentMethod string     `yaml:"deploymentMethod,omitempty"`
 	Version          string     `yaml:"version"`
 	ChartPath        string     `yaml:"chartPath"`
+	ChartsSource     string     `yaml:"chartsSource"`
 	Overrides        []Override `yaml:"overrides,omitempty"`
 	Namespace        string     `yaml:"namespace,omitempty"`
 	ValueFiles       []string   `yaml:"valueFiles,omitempty"`
@@ -34,12 +35,12 @@ type Override struct {
 }
 
 type HelmConfig struct {
-	Upgrade    bool              `yaml:"upgrade"`
-	Debug	   bool              `yaml:"debug"`
-	LogLevel	uint              `yaml:"log"`
-	ServiceAccount  string       `yaml:"serviceAccount"`
-	Repos      []HelmRepo        `yaml:"repos"`
-	Overrides  map[string]string `yaml:"overrides"`
+	Upgrade        bool              `yaml:"upgrade"`
+	Debug          bool              `yaml:"debug"`
+	LogLevel       uint              `yaml:"log"`
+	ServiceAccount string            `yaml:"serviceAccount"`
+	Repos          []HelmRepo        `yaml:"repos"`
+	Overrides      map[string]string `yaml:"overrides"`
 }
 
 type Value struct {

--- a/utils/report/report.go
+++ b/utils/report/report.go
@@ -20,17 +20,18 @@ type ReportKey struct {
 }
 
 type ReportDetail struct {
-	Version    string
-	ChartPath  string
-	Overrides  string
-	ValueFiles string
+	Version      string
+	ChartPath    string
+	ChartsSource string
+	Overrides    string
+	ValueFiles   string
 }
 
 func NewReport() Report {
 
 	return Report{
 		ReportFile:   "auditreport.csv",
-		ReportHeader: "Name,Cluster,Namespace,Version,ChartPath,ValueFiles",
+		ReportHeader: "Name,Cluster,Namespace,Version,ChartPath,ChartsSource,ValueFiles",
 		ReportLines:  make(map[ReportKey]ReportDetail),
 	}
 }
@@ -41,12 +42,13 @@ func (rpt *Report) Add(reportkey ReportKey, detail ReportDetail) {
 
 func (rpt *Report) Write(fName string) error {
 	type reportline struct {
-		Name       string
-		Cluster    string
-		Namespace  string
-		Version    string
-		ChartPath  string
-		ValueFiles string
+		Name         string
+		Cluster      string
+		Namespace    string
+		Version      string
+		ChartPath    string
+		ChartsSource string
+		ValueFiles   string
 	}
 	fd, err := os.Create(fName)
 	if err != nil {
@@ -57,17 +59,18 @@ func (rpt *Report) Write(fName string) error {
 	// Report header
 	fmt.Fprintln(fd, rpt.ReportHeader)
 	for key, line := range rpt.ReportLines {
-		t, err := template.New("Report").Parse("{{.Name}},{{.Cluster}},{{.Namespace}},{{.Version}},{{.ChartPath}},{{.ValueFiles}}\n")
+		t, err := template.New("Report").Parse("{{.Name}},{{.Cluster}},{{.Namespace}},{{.Version}},{{.ChartPath}},{{.ChartsSource}},{{.ValueFiles}}\n")
 		if err != nil {
 			panic(err)
 		}
 		item := reportline{
-			Name:       key.Name,
-			Cluster:    key.Cluster,
-			Namespace:  key.Namespace,
-			Version:    line.Version,
-			ChartPath:  line.ChartPath,
-			ValueFiles: line.ValueFiles,
+			Name:         key.Name,
+			Cluster:      key.Cluster,
+			Namespace:    key.Namespace,
+			Version:      line.Version,
+			ChartPath:    line.ChartPath,
+			ChartsSource: line.ChartsSource,
+			ValueFiles:   line.ValueFiles,
 		}
 		err = t.Execute(fd, item)
 		if err != nil {


### PR DESCRIPTION
with the new configuration option it is possible to install helm chart from tar file, for example `istio`
Config:
```
name: cluster2-lab
helm:
  log: 0
  debug: true
  repos:
    - name: stable
      url: https://kubernetes-charts.storage.googleapis.com/
releases:
  - name: istio-base
    namespace: kube-system
    version: ~x.x.x
    chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
    chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"

```

Output:
- First run downloads tar file:
```
2020/06/03 22:17:11 Installing addon: istio-base @ ~x.x.x
2020/06/03 22:17:11 Charts Source defined for: istio-base
2020/06/03 22:17:11 Downloading: ./downloads/istio-1.6.0-linux-amd64.tar.gz
2020/06/03 22:17:11 RUNNING: wget -P ./downloads https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz
--2020-06-03 22:17:11--  https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz
Resolving github.com (github.com)... 140.82.112.4
Connecting to github.com (github.com)|140.82.112.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-production-release-asset-2e65be.s3.amazonaws.com/74175805/44ae7c80-9b56-11ea-8548-ed97ea53c4b6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200604%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200604T031711Z&X-Amz-Expires=300&X-Amz-Signature=9b75bd1bf381f2b3de0d6d390de95ebe5f3501b67890143c1da45d94b84532fe&X-Amz-SignedHeaders=host&actor_id=0&repo_id=74175805&response-content-disposition=attachment%3B%20filename%3Distio-1.6.0-linux-amd64.tar.gz&response-content-type=application%2Foctet-stream [following]
--2020-06-03 22:17:11--  https://github-production-release-asset-2e65be.s3.amazonaws.com/74175805/44ae7c80-9b56-11ea-8548-ed97ea53c4b6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200604%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200604T031711Z&X-Amz-Expires=300&X-Amz-Signature=9b75bd1bf381f2b3de0d6d390de95ebe5f3501b67890143c1da45d94b84532fe&X-Amz-SignedHeaders=host&actor_id=0&repo_id=74175805&response-content-disposition=attachment%3B%20filename%3Distio-1.6.0-linux-amd64.tar.gz&response-content-type=application%2Foctet-stream
Resolving github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)... 52.216.165.179
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (github-production-release-asset-2e65be.s3.amazonaws.com)|52.216.165.179|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 39675836 (38M) [application/octet-stream]
Saving to: ‘./downloads/istio-1.6.0-linux-amd64.tar.gz’

istio-1.6.0-linux-amd64.tar.gz                               100%[===========================================================================================================================================>]  37.84M  7.54MB/s    in 6.4s

2020-06-03 22:17:18 (5.89 MB/s) - ‘./downloads/istio-1.6.0-linux-amd64.tar.gz’ saved [39675836/39675836]

2020/06/03 22:17:18 RUNNING: tar -xzf ./downloads/istio-1.6.0-linux-amd64.tar.gz -C ./downloads
2020/06/03 22:17:19 RUNNING: helm upgrade --install istio-base ./downloads/istio-1.6.0/manifests/charts/base --version ~x.x.x --kube-context lab1-cluster --namespace kube-system
Release "istio-base" has been upgraded. Happy Helming!
NAME: istio-base
LAST DEPLOYED: Wed Jun  3 22:17:51 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 6
TEST SUITE: None
```
- subsequent runs do not download tar file:
```
2020/06/03 21:47:28 Installing addon: istio-base @ ~x.x.x
2020/06/03 21:47:28 Charts Source defined for: istio-base
2020/06/03 21:47:28 File exist, skipping download: ./downloads/istio-1.6.0-linux-amd64.tar.gz
2020/06/03 21:47:28 RUNNING: tar -xzf ./downloads/istio-1.6.0-linux-amd64.tar.gz -C ./downloads
2020/06/03 21:47:29 RUNNING: helm upgrade --install istio-base ./downloads/istio-1.6.0/manifests/charts/base --version ~x.x.x --kube-context lab1-cluster --namespace kube-system
Release "istio-base" has been upgraded. Happy Helming!
NAME: istio-base
LAST DEPLOYED: Wed Jun  3 21:47:32 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 5
TEST SUITE: None
```