### PR TITLE
feat: add history field to control helm --history-max

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ releases:
     namespace: kube-system  # Specify the namespace where to install
     version: 0.7.0  # Specify the version of the chart to install
     deploymentMethod: helm # Specify how the chart should be installed ("helm" or "kubectl")
+    history: 3  # Optional; sets the --history-max flag for the "helm" deployment method
   - name: my-chart
     chartPath: private-repo/my-chart
     namespace: kube-system

--- a/plugin.go
+++ b/plugin.go
@@ -165,6 +165,9 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 	} else {
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "upgrade"})
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--install"})
+		if release.History > 0 {
+			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeLongParam, Name: "history-max", Value: fmt.Sprint(release.History)})
+		}
 	}
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.Name})
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.ChartPath})

--- a/types/types.go
+++ b/types/types.go
@@ -24,6 +24,7 @@ type Release struct {
 	Version          string     `yaml:"version"`
 	ChartPath        string     `yaml:"chartPath"`
 	ChartsSource     string     `yaml:"chartsSource"`
+	History          uint       `yaml:history`
 	Overrides        []Override `yaml:"overrides,omitempty"`
 	Namespace        string     `yaml:"namespace,omitempty"`
 	ValueFiles       []string   `yaml:"valueFiles,omitempty"`


### PR DESCRIPTION
Add the `history` field to the `Release` struct. This allows configuring Helm's `--history-max` setting when the `helm` deployment method is used.