### PR TITLE
Support setting overrides from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,40 @@ releases:
     chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
     chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"
 ```
+
+## Additional examples
+
+### Override values with environment variables
+Override a single value using Helm's `--set` feature.
+
+Add the following release to your cluster YAML file:
+```yaml
+- name: release-name
+  namespace: default
+  version: 1.0.0
+  chartPath: repo/chart-name
+  overrides:
+    - target: tls.key
+      showValue: false
+      valueFrom:
+        environment: KEY
+```
+
+If you set `showValue` to `true`, the value of the environment variable will logged to `stdout` for debugging purposes. By default, the value is redacted.
+
+### Override values with files
+Override a single value from a file using Helm's `--set-file` feature.
+
+Add the following release to your cluster YAML file:
+```yaml
+- name: release-name
+  namespace: default
+  version: 1.0.0
+  chartPath: repo/chart-name
+  overrides:
+    - target: tls.key
+      valueFrom:
+        file: /path/to/key
+```
+
+Because the value is not logged, `showValue` has no effect when setting values from file. The file path is always logged to `stdout`.

--- a/plugin.go
+++ b/plugin.go
@@ -384,26 +384,15 @@ func (p *Plugin) overrides(release *types.Release) (args []commandbuilder.Arg) {
 			Name:  "f",
 			Value: path})
 	}
-	isSecret := true
 	// Handle individual value overrides
 	for _, override := range release.Overrides {
 		log.Println("Overriding value for:", override.Target)
-		overrideValue, err := override.GetValue()
+		arg, err := override.BuildArg()
 		if err != nil {
 			log.Println("WARNING: Could not get override value. Skipping override:", err)
 			continue
 		}
-		if overrideValue == "" {
-			log.Println("WARNING: Override value is blank.")
-		}
-		if override.ShowValue {
-			isSecret = false
-		}
-		args = append(args, commandbuilder.Arg{
-			Type:        commandbuilder.ArgTypeLongParam,
-			Name:        "set",
-			Value:       fmt.Sprintf("%s=%s", override.Target, overrideValue),
-			ValueSecret: isSecret})
+		args = append(args, *arg)
 	}
 
 	return args

--- a/types/types.go
+++ b/types/types.go
@@ -2,7 +2,11 @@ package types
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
+
+	"github.com/target/impeller/utils/commandbuilder"
 )
 
 type ClusterConfig struct {
@@ -35,6 +39,14 @@ type Override struct {
 	Target string `yaml:"target"`
 }
 
+/// BuildArg creates a commandbuilder.Arg for either a `--set` or
+/// `--set-file` argument. If the value is provided directly or as an
+/// environment variable, `--set` will be used. If a file is provided,
+/// then `--set-file` will be used.
+func (o Override) BuildArg() (*commandbuilder.Arg, error) {
+	return o.Value.BuildArg(o.Target)
+}
+
 type HelmConfig struct {
 	Upgrade        bool              `yaml:"upgrade"`
 	DefaultHistory uint              `yaml:"defaultHistory"`
@@ -51,6 +63,26 @@ type Value struct {
 	ShowValue bool       `yaml:"showValue"`
 }
 
+func (v Value) BuildArg(name string) (*commandbuilder.Arg, error) {
+	if v.Value != nil {
+		if *v.Value == "" {
+			log.Println("WARNING: Override value is blank.")
+		}
+		return &commandbuilder.Arg{
+			Type:        commandbuilder.ArgTypeLongParam,
+			Name:        "set",
+			Value:       fmt.Sprintf("%s=%s", name, *v.Value),
+			ValueSecret: !v.ShowValue,
+		}, nil
+	} else if v.ValueFrom != nil {
+		return v.ValueFrom.BuildArg(name, v.ShowValue)
+	} else {
+		return nil, fmt.Errorf("no value provided")
+	}
+}
+
+/// GetValue returns the override value as a string. If a file or environment
+/// variable is set, the contents are read import ()and returned as a string.
 func (v Value) GetValue() (string, error) {
 	if v.Value != nil {
 		return *v.Value, nil
@@ -58,13 +90,50 @@ func (v Value) GetValue() (string, error) {
 	if v.ValueFrom != nil {
 		return v.ValueFrom.GetValue()
 	}
-	return "", fmt.Errorf("No value provided")
+	return "", fmt.Errorf("no value provided")
 }
 
 type ValueFrom struct {
 	Environment string `yaml:"environment"`
+	File        string `yaml:"file"`
+}
+
+func (vf ValueFrom) BuildArg(name string, show bool) (*commandbuilder.Arg, error) {
+	if vf.Environment != "" {
+		value, err := vf.GetValue()
+		if err != nil {
+			return nil, err
+		}
+		if value == "" {
+			log.Println("WARNING: Override value is blank.")
+		}
+		return &commandbuilder.Arg{
+			Type:        commandbuilder.ArgTypeLongParam,
+			Name:        "set",
+			Value:       fmt.Sprintf("%s=%s", name, value),
+			ValueSecret: !show,
+		}, nil
+	} else if vf.File != "" {
+		return &commandbuilder.Arg{
+			Type:        commandbuilder.ArgTypeLongParam,
+			Name:        "set-file",
+			Value:       fmt.Sprintf("%s=%s", name, vf.File),
+			ValueSecret: false,
+		}, nil
+	} else {
+		return nil, fmt.Errorf("no source specified for ValueFrom")
+	}
 }
 
 func (vf ValueFrom) GetValue() (string, error) {
-	return os.Getenv(vf.Environment), nil
+	if vf.Environment != "" {
+		return os.Getenv(vf.Environment), nil
+	} else if vf.File != "" {
+		bytes, err := ioutil.ReadFile(vf.File)
+		if err != nil {
+			return "", err
+		}
+		return string(bytes), nil
+	}
+	return "", fmt.Errorf("no source specified for ValueFrom")
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/target/impeller/utils/commandbuilder"
+)
+
+func TestOverrideBuildArgDirectValue(t *testing.T) {
+	value := "test"
+	override := Override{
+		Value: Value{
+			Value:     &value,
+			ShowValue: true,
+		},
+		Target: "value",
+	}
+
+	arg, err := override.BuildArg()
+	require.NoError(t, err)
+	assert.Equal(t, &commandbuilder.Arg{
+		Type:        commandbuilder.ArgTypeLongParam,
+		Name:        "set",
+		Value:       "value=test",
+		ValueSecret: false,
+	}, arg)
+}
+
+func TestOverrideBuildArgEnvironment(t *testing.T) {
+	os.Setenv("TEST_ENV", "test-value")
+	override := Override{
+		Value: Value{
+			ValueFrom: &ValueFrom{
+				Environment: "TEST_ENV",
+			},
+			ShowValue: false,
+		},
+		Target: "value",
+	}
+
+	arg, err := override.BuildArg()
+	require.NoError(t, err)
+	assert.Equal(t, &commandbuilder.Arg{
+		Type:        commandbuilder.ArgTypeLongParam,
+		Name:        "set",
+		Value:       "value=test-value",
+		ValueSecret: true,
+	}, arg)
+}
+
+func TestOverrideBuildArgFile(t *testing.T) {
+	override := Override{
+		Value: Value{
+			ValueFrom: &ValueFrom{
+				File: "/tmp/fake-file",
+			},
+			ShowValue: true,
+		},
+		Target: "value",
+	}
+
+	arg, err := override.BuildArg()
+	require.NoError(t, err)
+	assert.Equal(t, &commandbuilder.Arg{
+		Type:        commandbuilder.ArgTypeLongParam,
+		Name:        "set-file",
+		Value:       "value=/tmp/fake-file",
+		ValueSecret: false,
+	}, arg)
+}


### PR DESCRIPTION
Add support for overriding values from files with Helm's `--set-file` flag.

Example release overriding `tls.key` with the contents of the file `/path/to/key`:
```yaml
- name: release-name
  namespace: default
  version: 1.0.0
  chartPath: repo/chart-name
  overrides:
    - target: tls.key
      valueFrom:
        file: /path/to/key
```