### PR TITLE
Add force options for resource updation

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -179,6 +179,10 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 		} else if p.ClusterConfig.Helm.DefaultHistory > 0 {
 			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeLongParam, Name: "history-max", Value: fmt.Sprint(p.ClusterConfig.Helm.DefaultHistory)})
 		}
+
+		if p.ClusterConfig.Helm.Force {
+			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force"})
+		}
 	}
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.Name})
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.ChartPath})
@@ -187,10 +191,6 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 
 	if p.ClusterConfig.Helm.Debug {
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--debug"})
-	}
-
-	if p.ClusterConfig.Helm.Force {
-		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force"})
 	}
 
 	// Add namespaces to command

--- a/plugin.go
+++ b/plugin.go
@@ -180,7 +180,8 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeLongParam, Name: "history-max", Value: fmt.Sprint(p.ClusterConfig.Helm.DefaultHistory)})
 		}
 
-		if p.ClusterConfig.Helm.Force {
+		if release.Force {
+			log.Println("Running with Force:", release.Name)
 			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force"})
 		}
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -189,6 +189,10 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--debug"})
 	}
 
+	if p.ClusterConfig.Helm.Force {
+		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force"})
+	}
+
 	// Add namespaces to command
 	if release.Namespace != "" {
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeLongParam, Name: "namespace", Value: release.Namespace})

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -76,7 +76,6 @@ func TestPlugin_ExecReport(t *testing.T) {
 		KubeConfig:        "",
 		KubeContext:       "",
 		Dryrun:            false,
-		Force              false,
 		Diffrun:           false,
 		Audit:             true,
 		AuditFile:         "./go-test.csv",

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -76,6 +76,7 @@ func TestPlugin_ExecReport(t *testing.T) {
 		KubeConfig:        "",
 		KubeContext:       "",
 		Dryrun:            false,
+		Force              false,
 		Diffrun:           false,
 		Audit:             true,
 		AuditFile:         "./go-test.csv",

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -2,7 +2,6 @@ name: cluster2-lab
 helm:
   log: 0
   debug: true
-  force: true
   repos:
     - name: stable
       url: https://charts.helm.sh/stable
@@ -12,3 +11,9 @@ releases:
     version: ~x.x.x
     chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
     chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
+  - name: istio-base-force
+    namespace: kube-system
+    version: ~x.x.x
+    chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
+    chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
+    force: true

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -2,6 +2,7 @@ name: cluster2-lab
 helm:
   log: 0
   debug: true
+  Force: true
   repos:
     - name: stable
       url: https://kubernetes-charts.storage.googleapis.com/

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -11,9 +11,9 @@ releases:
     version: ~x.x.x
     chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
     chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
-  - name: istio-base-force
+  - name: istio-ingress
     namespace: kube-system
     version: ~x.x.x
-    chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
+    chartPath: "./downloads/istio-1.11.5/manifests/charts/gateways/istio-ingress"
     chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
     force: true

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -10,5 +10,5 @@ releases:
   - name: istio-base
     namespace: kube-system
     version: ~x.x.x
-    chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
-    chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"
+    chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
+    chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -2,10 +2,10 @@ name: cluster2-lab
 helm:
   log: 0
   debug: true
-  Force: true
+  force: true
   repos:
     - name: stable
-      url: https://kubernetes-charts.storage.googleapis.com/
+      url: https://charts.helm.sh/stable
 releases:
   - name: istio-base
     namespace: kube-system

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,7 @@ type Release struct {
 	Overrides        []Override `yaml:"overrides,omitempty"`
 	Namespace        string     `yaml:"namespace,omitempty"`
 	ValueFiles       []string   `yaml:"valueFiles,omitempty"`
+	Force            bool       `yaml:"force"`
 }
 
 type Override struct {
@@ -53,7 +54,6 @@ type HelmConfig struct {
 	SkipSetupKubeConfig bool              `yaml:"skipSetupKubeConfig"`
 	DefaultHistory      uint              `yaml:"defaultHistory"`
 	Debug               bool              `yaml:"debug"`
-	Force               bool              `yaml:"force"`
 	LogLevel            uint              `yaml:"log"`
 	ServiceAccount      string            `yaml:"serviceAccount"`
 	Repos               []HelmRepo        `yaml:"repos"`

--- a/types/types.go
+++ b/types/types.go
@@ -53,6 +53,7 @@ type HelmConfig struct {
 	SkipSetupKubeConfig bool              `yaml:"skipSetupKubeConfig"`
 	DefaultHistory      uint              `yaml:"defaultHistory"`
 	Debug               bool              `yaml:"debug"`
+	Force								bool							`yaml:"force"`
 	LogLevel            uint              `yaml:"log"`
 	ServiceAccount      string            `yaml:"serviceAccount"`
 	Repos               []HelmRepo        `yaml:"repos"`

--- a/types/types.go
+++ b/types/types.go
@@ -53,7 +53,7 @@ type HelmConfig struct {
 	SkipSetupKubeConfig bool              `yaml:"skipSetupKubeConfig"`
 	DefaultHistory      uint              `yaml:"defaultHistory"`
 	Debug               bool              `yaml:"debug"`
-	Force								bool							`yaml:"force"`
+	Force               bool							`yaml:"force"`
 	LogLevel            uint              `yaml:"log"`
 	ServiceAccount      string            `yaml:"serviceAccount"`
 	Repos               []HelmRepo        `yaml:"repos"`

--- a/types/types.go
+++ b/types/types.go
@@ -53,7 +53,7 @@ type HelmConfig struct {
 	SkipSetupKubeConfig bool              `yaml:"skipSetupKubeConfig"`
 	DefaultHistory      uint              `yaml:"defaultHistory"`
 	Debug               bool              `yaml:"debug"`
-	Force               bool							`yaml:"force"`
+	Force               bool              `yaml:"force"`
 	LogLevel            uint              `yaml:"log"`
 	ServiceAccount      string            `yaml:"serviceAccount"`
 	Repos               []HelmRepo        `yaml:"repos"`


### PR DESCRIPTION
- What I did
Add force options on update to avoid resource constraints/conflicts with current config vs update config.

- Why I did it
`--force:                        force resource updates through a replacement strategy`
--force will delete the resource which has failed due to conflicts.
Can be enabled during major upgrades with K8s Version to avoid API Kind version issue.

- How I did it
https://github.com/helm/helm/pull/2280
- How to verify it
```
2022/02/11 17:34:25 RUNNING: tar -xzf ./downloads/istio-1.11.5-linux-amd64.tar.gz -C ./downloads
2022/02/11 17:34:26 Running Dry run: istio-base
2022/02/11 17:34:26 RUNNING: helm upgrade --install --force istio-base ./downloads/istio-1.11.5/manifests/charts/base --version ~x.x.x --kube-context colima --debug --namespace kube-system --dry-run
history.go:56: [debug] getting history for release istio-base
Release "istio-base" does not exist. Installing it now.
install.go:178: [debug] Original chart version: "~x.x.x"
install.go:195: [debug] CHART PATH: /Users/Z0035RX/github/kannanthiru/impeller/downloads/istio-1.11.5/manifests/charts/base

install.go:210: [debug] WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.
NAME: istio-base
LAST DEPLOYED: Fri Feb 11 17:34:28 2022
NAMESPACE: kube-system
STATUS: pending-install
REVISION: 1
TEST SUITE: None
USER-SUPPLIED VALUES:
```
Its option part of chart. no impact if no Force attribute mentioned.
- Meme/emoji that summarize this change (not mandatory)
