### PR TITLE
Revert "Add force options for resource updation"

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -179,11 +179,6 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 		} else if p.ClusterConfig.Helm.DefaultHistory > 0 {
 			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeLongParam, Name: "history-max", Value: fmt.Sprint(p.ClusterConfig.Helm.DefaultHistory)})
 		}
-
-		if release.Force {
-			log.Println("Running with Force:", release.Name)
-			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force"})
-		}
 	}
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.Name})
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: release.ChartPath})

--- a/test-clusters/cluster2-lab.yaml
+++ b/test-clusters/cluster2-lab.yaml
@@ -4,16 +4,10 @@ helm:
   debug: true
   repos:
     - name: stable
-      url: https://charts.helm.sh/stable
+      url: https://kubernetes-charts.storage.googleapis.com/
 releases:
   - name: istio-base
     namespace: kube-system
     version: ~x.x.x
-    chartPath: "./downloads/istio-1.11.5/manifests/charts/base"
-    chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
-  - name: istio-ingress
-    namespace: kube-system
-    version: ~x.x.x
-    chartPath: "./downloads/istio-1.11.5/manifests/charts/gateways/istio-ingress"
-    chartsSource: "https://github.com/istio/istio/releases/download/1.11.5/istio-1.11.5-linux-amd64.tar.gz"
-    force: true
+    chartPath: "./downloads/istio-1.6.0/manifests/charts/base"
+    chartsSource: "https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz"

--- a/types/types.go
+++ b/types/types.go
@@ -32,7 +32,6 @@ type Release struct {
 	Overrides        []Override `yaml:"overrides,omitempty"`
 	Namespace        string     `yaml:"namespace,omitempty"`
 	ValueFiles       []string   `yaml:"valueFiles,omitempty"`
-	Force            bool       `yaml:"force"`
 }
 
 type Override struct {


### PR DESCRIPTION
Reverts target/impeller#38

`--force` has no action on these diff package issue.

detailed explanation here: https://helm.sh/docs/topics/kubernetes_apis/#helm-users