### PR TITLE
Update helm template logic

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -240,7 +240,7 @@ func (p *Plugin) installAddonViaKubectl(release *types.Release) error {
 
 	cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "apply"})
 	// Dry Run
-	if p.Dryrun {
+	if p.Dryrun || p.Diffrun {
 		log.Println("Running Dry run:", release.Name)
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--dry-run=server"})
 	}

--- a/utils/commandbuilder/commandbuilder.go
+++ b/utils/commandbuilder/commandbuilder.go
@@ -32,7 +32,7 @@ func (cb *CommandBuilder) Command() *exec.Cmd {
 	for _, arg := range cb.Parts {
 		args = append(args, arg.UnsafeParts()...)
 	}
-
+	log.Printf("RUNNING: %s", cb.SafeString())
 	return exec.Command(cb.Name, args...)
 }
 
@@ -41,7 +41,6 @@ func (cb *CommandBuilder) Add(args ...Arg) {
 }
 
 func (cb *CommandBuilder) Run() error {
-	log.Printf("RUNNING: %s", cb.SafeString())
 	cmd := cb.Command()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
- What I did
Updated code for generating yaml files using helm template and applying with kubectl.


- How to verify it
ran code locally 
1. Dry run is on:
```
"kubernetes-charts" already exists with the same configuration, skipping
2022/05/01 16:48:09 Updating Helm repos
2022/05/01 16:48:09 RUNNING: helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "kubernetes-charts" chart repository
Update Complete. ⎈Happy Helming!⎈
2022/05/01 16:48:09 Installing addon: test-me @ 1.10.1
2022/05/01 16:48:09 Adding override file: values/test-me/default.yaml
2022/05/01 16:48:09 RUNNING: helm template test-me kubernetes-charts/my-helm --version 1.10.1 -f values/test -me/default.yaml
2022/05/01 16:48:09 Running Dry run: bootstrap-dns
2022/05/01 16:48:09 RUNNING: kubectl --namespace kube-system --context my-cluster-name apply --dry-run=server --filename -
2022/05/01 16:48:09 RUNNING COMMAND: (command hidden)
clusterrole.rbac.authorization.k8s.io/my-role-1 unchanged (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/my-role-2 unchanged (server dry run)


```
2. Dry run is off:
```
"kubernetes-charts" already exists with the same configuration, skipping
2022/05/01 16:48:09 Updating Helm repos
2022/05/01 16:48:09 RUNNING: helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "kubernetes-charts" chart repository
Update Complete. ⎈Happy Helming!⎈
2022/05/01 16:48:09 Installing addon: test-me @ 1.10.1
2022/05/01 16:48:09 Adding override file: values/test-me/default.yaml
2022/05/01 16:48:09 RUNNING: helm template test-me kubernetes-charts/my-helm --version 1.10.1 -f values/test -me/default.yaml
2022/05/01 16:48:09 RUNNING: kubectl --namespace kube-system --context my-cluster-name apply --dry-run=server --filename -
2022/05/01 16:48:09 RUNNING COMMAND: (command hidden)
clusterrole.rbac.authorization.k8s.io/my-role-1 unchanged
clusterrolebinding.rbac.authorization.k8s.io/my-role-2 unchanged

```



