### PR TITLE
update helm and helmdiff versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15-alpine as builder
-ENV DESIRED_VERSION=v3.8.0
-ENV HELM_DIFF_VERSION=v3.4.0
+ENV DESIRED_VERSION=v3.9.0
+ENV HELM_DIFF_VERSION=v3.5.0
 WORKDIR /go/src/github.com/target/impeller
 COPY . .
 ENV GO111MODULE=on

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /tmp && \
 RUN /usr/local/bin/helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
 
 FROM alpine:latest
-ENV KUBECTL_VERSION=v1.23.4
+ENV KUBECTL_VERSION=v1.23.9
 RUN apk add ca-certificates
 RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~
 or using `base64` encoded `kubeconfig`:
 
 ```bash
-impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(base64 ~/.kube/config)" --kube-context my-kubernetes-context
+impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(base64 ~/.kube/config)" --kube-context my-kubernetes-context --kube-config-base64=true
 ```
 2. Dry run command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,11 +26,22 @@ Manages Helm charts running in Kubernetes clusters.
 ## How to use
 ### Command line
 1. Deployment command:
-`impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context`
-2. Dry run command:
-`impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context --dry-run`
-By default override values are hidden with `--dry-run` option. You can add `showValue: true` to your release to enable printout:
+
+```bash
+impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context
 ```
+
+or using `base64` encoded `kubeconfig`:
+
+```bash
+impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(base64 ~/.kube/config)" --kube-context my-kubernetes-context
+```
+2. Dry run command:
+```bash
+ impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context --dry-run
+ ```
+By default override values are hidden with `--dry-run` option. You can add `showValue: true` to your release to enable printout:
+```bash
 releases:
   - name: test-release
     namespace: kube-system
@@ -41,11 +52,17 @@ releases:
         value: 1.6.0
 ```
 3. Diff run command:
-`impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context --diff-run`
+```bash
+impeller --cluster-config-path=./clusters/my-cluster.yaml --kube-config="$(cat ~/.kube/config)" --kube-context my-kubernetes-context --diff-run
+```
 4. Generate Audit report file:
-`impeller --cluster-config-path=./clusters  --audit=true`
+```bash
+impeller --cluster-config-path=./clusters  --audit=true
+```
 or
-`impeller --cluster-config-path=./clusters  --audit=true --audit-file=./myreport.csv`
+```bash
+impeller --cluster-config-path=./clusters  --audit=true --audit-file=./myreport.csv
+```
 
 ### Drone pipeline
 #### Simple example

--- a/main.go
+++ b/main.go
@@ -32,6 +32,11 @@ func main() {
 			Usage:  "Kubernetes configuration file",
 			EnvVar: "KUBE_CONFIG,PLUGIN_KUBE_CONFIG,PARAMETER_KUBE_CONFIG",
 		},
+		cli.BoolFlag{
+			Name:   "kube-config-base64",
+			Usage:  "Flag true/false, base64 encoded kubeconfig",
+			EnvVar: "KUBE_CONFIG_BASE64,PLUGIN_KUBE_CONFIG_BASE64,PARAMETER_KUBE_CONFIG_BASE64",
+		},
 		cli.StringFlag{
 			Name:   "kube-context",
 			Usage:  "Kubernetes configuration context to use",
@@ -105,6 +110,7 @@ func run(ctx *cli.Context) error {
 		ClustersList:      clist,
 		ValueFiles:        ctx.StringSlice("value-files"),
 		KubeConfig:        ctx.String("kube-config"),
+		KubeConfigBase64:  ctx.Bool("kube-config-base64"),
 		KubeContext:       ctx.String("kube-context"),
 		Dryrun:            ctx.Bool("dry-run"),
 		Diffrun:           ctx.Bool("diff-run"),


### PR DESCRIPTION
- What I did
    - updated helm version to 3.9.0
    - updated helmdiff version to 3.5.0
    - update kubectl version to 1.23.9
    - added option to base64 encode kubeconfig file
    - added creation of a separate kubeconfig file for each context to prevent replacement of default ~/.kube/config
