### PR TITLE
add second docker file to build image with gcloud auth plugin

### DIFF
--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -52,12 +52,21 @@ jobs:
           tags: ${{ env.TEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Extract metadata (tags, labels) for Docker with gcloud
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: target/impeller
+          flavor: |
+            suffix=gcloud
+
       - name: Build and export to Docker with gcloud
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           file: ./Dockerfile-gcloud
           load: true
+          fla
           tags: ${{ env.TEST_GCLOUD_TAG }}
 
 

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -51,3 +51,28 @@ jobs:
           push: true
           tags: ${{ env.TEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: target/impeller
+
+      - name: Build and export to Docker with gcloud
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./Dockerfile-gcloud
+          load: true
+          tags: ${{ env.TEST_GCLOUD_TAG }}
+
+
+      - name: Build and push Docker image with gcloud
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./Dockerfile-gcloud
+          push: true
+          tags: ${{ env.TEST_GCLOUD_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -66,7 +66,6 @@ jobs:
           context: .
           file: ./Dockerfile-gcloud
           load: true
-          fla
           tags: ${{ env.TEST_GCLOUD_TAG }}
 
 

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -76,5 +76,5 @@ jobs:
           context: .
           file: ./Dockerfile-gcloud
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta-g.outputs.tags }}
           labels: ${{ steps.meta-g.outputs.labels }}

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -10,10 +10,22 @@ on:
 
 env:
   TEST_TAG: target/impeller:beta
+  TEST_GCLOUD_TAG: target/impeller:beta-gcloud
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile
+            tag:  target/impeller:beta
+          - dockerfile: ./Dockerfile-gcloud
+            tag: target/impeller:beta-gcloud
+    permissions:
+      contents: read
+      packages: write
     steps:
       -
         name: Checkout
@@ -36,14 +48,17 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           load: true
-          tags: ${{ env.TEST_TAG }}
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ matrix.tag }}
 
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ env.TEST_TAG }}
+          tags: ${{ matrix.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -52,12 +52,6 @@ jobs:
           tags: ${{ env.TEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: target/impeller
-
       - name: Build and export to Docker with gcloud
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -32,6 +32,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: target/impeller
+          flavor: |
+            latest=false
+            prefix=beta
+            suffix=
 
       - name: Build and export to Docker
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
@@ -58,6 +62,8 @@ jobs:
         with:
           images: target/impeller
           flavor: |
+            latest=false
+            prefix=beta
             suffix=gcloud
 
       - name: Build and export to Docker with gcloud

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -53,7 +53,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for Docker with gcloud
-        id: meta
+        id: meta-g
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: target/impeller
@@ -76,5 +76,5 @@ jobs:
           context: .
           file: ./Dockerfile-gcloud
           push: true
-          tags: ${{ env.TEST_GCLOUD_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta-g.outputs.labels }}

--- a/.github/workflows/ci-dev-pipeline.yaml
+++ b/.github/workflows/ci-dev-pipeline.yaml
@@ -15,17 +15,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile: ./Dockerfile
-            tag:  target/impeller:beta
-          - dockerfile: ./Dockerfile-gcloud
-            tag: target/impeller:beta-gcloud
-    permissions:
-      contents: read
-      packages: write
     steps:
       -
         name: Checkout
@@ -48,17 +37,17 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ./Dockerfile
           load: true
-          file: ${{ matrix.dockerfile }}
-          tags: ${{ matrix.tag }}
+          tags: ${{ env.TEST_TAG }}
+
 
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ./Dockerfile
           push: true
-          tags: ${{ matrix.tag }}
+          tags: ${{ env.TEST_TAG }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,3 +29,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./Dockerfile-gcloud
+          push: true
+          tags: "${{ steps.meta.outputs.tags }}-gcloud"
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for Docker gcloud
         id: meta-g
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
@@ -43,7 +43,7 @@ jobs:
             prefix=
             suffix=gcloud
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image gcloud
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,20 +5,6 @@ on:
     types: [published]
 
 jobs:
-  publish_to_registry:
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile: ./Dockerfile
-            tag:  ""
-          - dockerfile: ./Dockerfile-gcloud
-            tag: "-gcloud"
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -39,7 +25,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
+          file: ./Dockerfile
           push: true
-          tags: "${{ steps.meta.outputs.tags }}{{martix-tag}}"
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: target/impeller
-
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -30,11 +33,21 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta-g
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: target/impeller
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=gcloud
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           file: ./Dockerfile-gcloud
           push: true
-          tags: "${{ steps.meta.outputs.tags }}-gcloud"
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-g.outputs.tags }}
+          labels: ${{ steps.meta-g.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,17 @@ jobs:
   publish_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile
+            tag:  ""
+          - dockerfile: ./Dockerfile-gcloud
+            tag: "-gcloud"
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -28,6 +39,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: "${{ steps.meta.outputs.tags }}{{martix-tag}}"
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
 
 jobs:
+  publish_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.15-alpine as builder
-ENV DESIRED_VERSION=v3.9.0
+FROM golang:1.19-alpine as builder
+ENV DESIRED_VERSION=v3.10.2
 ENV HELM_DIFF_VERSION=v3.5.0
 WORKDIR /go/src/github.com/target/impeller
 COPY . .
@@ -20,12 +20,16 @@ RUN cd /tmp && \
     && ./get_helm.sh
 RUN /usr/local/bin/helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
 
-FROM alpine:latest
-ENV KUBECTL_VERSION=v1.23.9
+#FROM alpine:latest
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+RUN gcloud components install gke-gcloud-auth-plugin
+
+ENV KUBECTL_VERSION=v1.24.7
 RUN apk add ca-certificates
 RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl
 RUN mkdir /root/.kube
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 ENTRYPOINT ["/usr/bin/impeller"]
 COPY --from=builder /go/src/github.com/target/impeller/impeller /usr/bin/impeller
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/Dockerfile-gcloud
+++ b/Dockerfile-gcloud
@@ -20,7 +20,10 @@ RUN cd /tmp && \
     && ./get_helm.sh
 RUN /usr/local/bin/helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
 
-FROM alpine:latest
+#FROM alpine:latest
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+RUN gcloud components install gke-gcloud-auth-plugin
+
 ENV KUBECTL_VERSION=v1.24.7
 RUN apk add ca-certificates
 RUN wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \


### PR DESCRIPTION
- What I did
  - added second dockerfile to create image with gcloud
     -  the gcp auth plugin is deprecated, use gcloud instead
        - https://cloud.google.com/sdk/docs/downloads-docker
        - https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#gcloud_1
   - helm update to v3.10.2
   - kubectl update to 1.24.7
   - updated github actions to create 2 images


