### PR TITLE
fix: give server-side flag a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Manages Helm charts running in Kubernetes clusters.
 
 As of v3.6.0, impeller uses **Helm 4**. Helm 3 is only supported in versions prior to 3.6.0.
 
-All Helm-based deployments now use server-side apply (`--server-side`), including `helm diff` runs.
+All Helm-based deployments now use server-side apply (`--server-side=true`), including `helm diff` runs.
 
 ## Use Cases
 ### Managing multiple Helm charts

--- a/plugin.go
+++ b/plugin.go
@@ -209,7 +209,7 @@ func (p *Plugin) installAddonViaHelm(release *types.Release) error {
 	} else {
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "upgrade"})
 		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--install"})
-		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--server-side"})
+		cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--server-side=true"})
 		if release.ForceConflicts {
 			log.Println("ForceConflicts flag enabled: will force field ownership conflicts in server-side apply")
 			cb.Add(commandbuilder.Arg{Type: commandbuilder.ArgTypeRaw, Value: "--force-conflicts"})


### PR DESCRIPTION
Previously `helm upgrade` commands would fail without specifying this since `--server-side` doesn't seem to have a default value.

Signed-off-by: bzub <bzub@users.noreply.github.com>